### PR TITLE
Accept multiple status codes in HTTP checker

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -44,14 +44,14 @@ type dummyEnv struct {
 
 func main() {
 	httpChecker1 := healthchecks.NewHTTPChecker(healthchecks.HTTPCheckerConfig{
-		URL:            "https://www.wikipedia.org",
-		Name:           "wikipedia-http-check",
-		ExpectedStatus: http.StatusOK,
+		URL:              "https://www.wikipedia.org",
+		Name:             "wikipedia-http-check",
+		ExpectedStatuses: []int{http.StatusOK},
 	})
 	httpChecker2 := healthchecks.NewHTTPChecker(healthchecks.HTTPCheckerConfig{
-		URL:            "https://www.wikimedia.org",
-		Name:           "wikimedia-http-check",
-		ExpectedStatus: http.StatusOK,
+		URL:              "https://www.wikimedia.org",
+		Name:             "wikimedia-http-check",
+		ExpectedStatuses: []int{http.StatusOK},
 	})
 
 	sess, err := session.NewSession(&aws.Config{

--- a/health/http.go
+++ b/health/http.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 )
 
 // HTTPCheckerConfig holds configuration for the HTTPChecker.
 type HTTPCheckerConfig struct {
-	URL            string
-	Name           string
-	ExpectedStatus int
+	URL              string
+	Name             string
+	ExpectedStatuses []int
 }
 
 // HTTPChecker implements the HealthChecker interface for HTTP endpoints.
@@ -20,8 +21,8 @@ type HTTPChecker struct {
 
 // NewHTTPChecker creates a new HTTPChecker.
 func NewHTTPChecker(config HTTPCheckerConfig) *HTTPChecker {
-	if config.ExpectedStatus == 0 {
-		config.ExpectedStatus = http.StatusOK
+	if len(config.ExpectedStatuses) == 0 {
+		config.ExpectedStatuses = []int{http.StatusOK}
 	}
 
 	return &HTTPChecker{config: config}
@@ -42,8 +43,8 @@ func (c *HTTPChecker) Check(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 
-	if c.config.ExpectedStatus != 0 && resp.StatusCode != c.config.ExpectedStatus {
-		return fmt.Errorf("unexpected status code: got %d, want %d", resp.StatusCode, c.config.ExpectedStatus)
+	if !slices.Contains(c.config.ExpectedStatuses, resp.StatusCode) {
+		return fmt.Errorf("unexpected status code: got %d, want %v", resp.StatusCode, c.config.ExpectedStatuses)
 	}
 
 	return nil

--- a/health/http_test.go
+++ b/health/http_test.go
@@ -16,9 +16,9 @@ func TestHTTPChecker_Check_Success(t *testing.T) {
 	defer server.Close()
 
 	config := HTTPCheckerConfig{
-		URL:            server.URL,
-		Name:           "test-http-check",
-		ExpectedStatus: http.StatusOK,
+		URL:              server.URL,
+		Name:             "test-http-check",
+		ExpectedStatuses: []int{http.StatusTooManyRequests, http.StatusOK},
 	}
 	checker := NewHTTPChecker(config)
 
@@ -28,9 +28,9 @@ func TestHTTPChecker_Check_Success(t *testing.T) {
 
 func TestHTTPChecker_Check_RequestCreationError(t *testing.T) {
 	config := HTTPCheckerConfig{
-		URL:            "://invalid-url",
-		Name:           "test-http-check",
-		ExpectedStatus: http.StatusOK,
+		URL:              "://invalid-url",
+		Name:             "test-http-check",
+		ExpectedStatuses: []int{http.StatusOK},
 	}
 	checker := NewHTTPChecker(config)
 
@@ -48,9 +48,9 @@ func TestHTTPChecker_Check_UnexpectedStatusCode(t *testing.T) {
 	defer server.Close()
 
 	config := HTTPCheckerConfig{
-		URL:            server.URL,
-		Name:           "test-http-check",
-		ExpectedStatus: http.StatusOK,
+		URL:              server.URL,
+		Name:             "test-http-check",
+		ExpectedStatuses: []int{http.StatusOK},
 	}
 	checker := NewHTTPChecker(config)
 
@@ -67,7 +67,7 @@ func TestHTTPChecker_NewHTTPChecker_DefaultExpectedStatus(t *testing.T) {
 	}
 
 	checker := NewHTTPChecker(config)
-	assert.Equal(t, http.StatusOK, checker.config.ExpectedStatus) // default status is 200 OK
+	assert.Equal(t, []int{http.StatusOK}, checker.config.ExpectedStatuses) // default status is 200 OK
 }
 
 func TestHTTPChecker_Name(t *testing.T) {
@@ -95,9 +95,9 @@ func TestHTTPChecker_Check_ContextCancelled_BeforeRequest(t *testing.T) {
 	cancel()
 
 	config := HTTPCheckerConfig{
-		URL:            "http://example.com",
-		Name:           "test-http-check",
-		ExpectedStatus: http.StatusOK,
+		URL:              "http://example.com",
+		Name:             "test-http-check",
+		ExpectedStatuses: []int{http.StatusOK},
 	}
 	checker := NewHTTPChecker(config)
 	err := checker.Check(ctx)


### PR DESCRIPTION
This can be used to prevent unreliable or throttling HTTP dependencies from failing our healthchecks (e.g. WMF returns 429 from time to time).