### PR TITLE
add schema registry healthchecks with unit tests

### DIFF
--- a/health/schema_registry.go
+++ b/health/schema_registry.go
@@ -8,14 +8,14 @@ import (
 	"time"
 )
 
-// SchemaRegistryChecker verifies the availability of a Schema Registry.
+// SchemaRegistryChecker verifies that our service can connect to a Schema Registry instance.
 type SchemaRegistryChecker struct {
 	CheckerName string
 	URL         string
 	HTTPClient  HttpClient
 }
 
-// Check verifies Schema Registry is healthy by querying /subjects.
+// Check verifies Schema Registry is configured to query schema registry
 func (c *SchemaRegistryChecker) Check(ctx context.Context) error {
 	client := c.HTTPClient
 	if client == nil {
@@ -24,18 +24,18 @@ func (c *SchemaRegistryChecker) Check(ctx context.Context) error {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/subjects", c.URL), nil)
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return fmt.Errorf("error creating request: %w", err)
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to reach schema registry: %w", err)
+		return fmt.Errorf("error /subjects not reachable: %w", err)
 	}
 	defer resp.Body.Close()
 	io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("schema registry unhealthy: status %d", resp.StatusCode)
+		return fmt.Errorf("error unable to query /subjects: status %d", resp.StatusCode)
 	}
 
 	return nil

--- a/health/schema_registry.go
+++ b/health/schema_registry.go
@@ -1,0 +1,52 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// SchemaRegistryChecker verifies the availability of a Schema Registry.
+type SchemaRegistryChecker struct {
+	CheckerName string
+	URL         string
+	HTTPClient  HttpClient
+}
+
+// Check verifies Schema Registry is healthy by querying /subjects.
+func (c *SchemaRegistryChecker) Check(ctx context.Context) error {
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/subjects", c.URL), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to reach schema registry: %w", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("schema registry unhealthy: status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// Name returns the unique name of the schema registry health check.
+func (c *SchemaRegistryChecker) Name() string {
+	return c.CheckerName
+}
+
+// Type returns the type identifier for the health check.
+func (c *SchemaRegistryChecker) Type() string {
+	return "schema-registry"
+}

--- a/health/schema_registry.go
+++ b/health/schema_registry.go
@@ -24,7 +24,7 @@ func (c *SchemaRegistryChecker) Check(ctx context.Context) error {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/subjects", c.URL), nil)
 	if err != nil {
-		return fmt.Errorf("error creating schema request: %w", err)
+		return fmt.Errorf("error creating schema request: %w, url: %s", err, c.URL)
 	}
 
 	resp, err := client.Do(req)

--- a/health/schema_registry.go
+++ b/health/schema_registry.go
@@ -24,7 +24,7 @@ func (c *SchemaRegistryChecker) Check(ctx context.Context) error {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/subjects", c.URL), nil)
 	if err != nil {
-		return fmt.Errorf("error creating request: %w", err)
+		return fmt.Errorf("error creating schema request: %w", err)
 	}
 
 	resp, err := client.Do(req)

--- a/health/schema_registry_test.go
+++ b/health/schema_registry_test.go
@@ -30,7 +30,7 @@ func TestSchemaRegistryChecker_Check_Success(t *testing.T) {
 
 	checker := &SchemaRegistryChecker{
 		CheckerName: "schema-registry",
-		URL:         "http://fake-schema-registry",
+		URL:         "http://schema-registry",
 		HTTPClient:  client,
 	}
 

--- a/health/schema_registry_test.go
+++ b/health/schema_registry_test.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -15,7 +16,11 @@ type mockHTTPClient struct {
 }
 
 func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	return m.doFunc(req)
+	if m.doFunc != nil {
+		return m.doFunc(req)
+	}
+
+	return nil, errors.New("doFunc not implemented")
 }
 
 func TestSchemaRegistryChecker_Check_Success(t *testing.T) {
@@ -29,16 +34,16 @@ func TestSchemaRegistryChecker_Check_Success(t *testing.T) {
 	}
 
 	checker := &SchemaRegistryChecker{
-		CheckerName: "schema-registry",
-		URL:         "http://schema-registry",
+		CheckerName: "schema-registry-ok",
+		URL:         "http://fake-schema-registry:8081",
 		HTTPClient:  client,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	if err := checker.Check(ctx); err != nil {
-		t.Fatalf("expected success, got error: %v", err)
+		t.Fatalf("expected success, but got error: %v", err)
 	}
 }
 
@@ -47,50 +52,75 @@ func TestSchemaRegistryChecker_Check_Failure_StatusCode(t *testing.T) {
 		doFunc: func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusInternalServerError,
-				Body:       io.NopCloser(strings.NewReader(`server error`)),
+				Body:       io.NopCloser(strings.NewReader(`{"error_code":50001,"message":"Error in the backend"}`)),
 			}, nil
 		},
 	}
 
 	checker := &SchemaRegistryChecker{
-		CheckerName: "schema-registry",
-		URL:         "http://fake-schema-registry",
+		CheckerName: "schema-registry-bad-status",
+		URL:         "http://fake-schema-registry:8081",
 		HTTPClient:  client,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	err := checker.Check(ctx)
 	if err == nil {
-		t.Fatal("expected error due to non-200 status code, got nil")
+		t.Fatal("expected an error due to non-200 status code, but got nil")
 	}
-	if !strings.Contains(err.Error(), "unhealthy") {
-		t.Errorf("expected error to mention 'unhealthy', got: %v", err)
+
+	expectedErrorSubstring := "error unable to query /subjects: status 500"
+	if !strings.Contains(err.Error(), expectedErrorSubstring) {
+		t.Errorf("expected error message to contain '%s', but got: '%v'", expectedErrorSubstring, err)
 	}
 }
 
-func TestSchemaRegistryChecker_Check_Failure_RequestError(t *testing.T) {
+func TestSchemaRegistryChecker_Check_Failure_ClientDoError(t *testing.T) {
 	client := &mockHTTPClient{
 		doFunc: func(req *http.Request) (*http.Response, error) {
-			return nil, io.ErrUnexpectedEOF
+			return nil, errors.New("connection refused")
 		},
 	}
 
 	checker := &SchemaRegistryChecker{
-		CheckerName: "schema-registry",
-		URL:         "http://fake-schema-registry",
+		CheckerName: "schema-registry-client-error",
+		URL:         "http://unreachable-schema-registry:8081",
 		HTTPClient:  client,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	err := checker.Check(ctx)
 	if err == nil {
-		t.Fatal("expected error due to request failure, got nil")
+		t.Fatal("expected an error due to request failure, but got nil")
 	}
-	if !strings.Contains(err.Error(), "failed to reach") {
-		t.Errorf("expected error to mention 'failed to reach', got: %v", err)
+
+	expectedErrorSubstring := "error /subjects not reachable"
+	if !strings.Contains(err.Error(), expectedErrorSubstring) {
+		t.Errorf("expected error message to contain '%s', but got: '%v'", expectedErrorSubstring, err)
+	}
+}
+
+func TestSchemaRegistryChecker_Check_Failure_NewRequestError(t *testing.T) {
+	checker := &SchemaRegistryChecker{
+		CheckerName: "schema-registry-bad-url",
+		URL:         "http://invalid-url:\n",
+		HTTPClient:  &mockHTTPClient{},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := checker.Check(ctx)
+	if err == nil {
+		t.Fatal("expected an error due to invalid request creation, but got nil")
+	}
+
+	expectedErrorSubstring := "error creating schema request"
+	if !strings.Contains(err.Error(), expectedErrorSubstring) {
+		t.Errorf("expected error message to contain '%s', but got: '%v'", expectedErrorSubstring, err)
 	}
 }

--- a/health/schema_registry_test.go
+++ b/health/schema_registry_test.go
@@ -1,0 +1,96 @@
+package health
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockHTTPClient lets us stub HTTP responses for tests.
+type mockHTTPClient struct {
+	doFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.doFunc(req)
+}
+
+func TestSchemaRegistryChecker_Check_Success(t *testing.T) {
+	client := &mockHTTPClient{
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`["subject1","subject2"]`)),
+			}, nil
+		},
+	}
+
+	checker := &SchemaRegistryChecker{
+		CheckerName: "schema-registry",
+		URL:         "http://fake-schema-registry",
+		HTTPClient:  client,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := checker.Check(ctx); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+}
+
+func TestSchemaRegistryChecker_Check_Failure_StatusCode(t *testing.T) {
+	client := &mockHTTPClient{
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader(`server error`)),
+			}, nil
+		},
+	}
+
+	checker := &SchemaRegistryChecker{
+		CheckerName: "schema-registry",
+		URL:         "http://fake-schema-registry",
+		HTTPClient:  client,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := checker.Check(ctx)
+	if err == nil {
+		t.Fatal("expected error due to non-200 status code, got nil")
+	}
+	if !strings.Contains(err.Error(), "unhealthy") {
+		t.Errorf("expected error to mention 'unhealthy', got: %v", err)
+	}
+}
+
+func TestSchemaRegistryChecker_Check_Failure_RequestError(t *testing.T) {
+	client := &mockHTTPClient{
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			return nil, io.ErrUnexpectedEOF
+		},
+	}
+
+	checker := &SchemaRegistryChecker{
+		CheckerName: "schema-registry",
+		URL:         "http://fake-schema-registry",
+		HTTPClient:  client,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := checker.Check(ctx)
+	if err == nil {
+		t.Fatal("expected error due to request failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to reach") {
+		t.Errorf("expected error to mention 'failed to reach', got: %v", err)
+	}
+}


### PR DESCRIPTION
Changes:
* Health checks for schema registry
* All healthchecks pass locally. 

`{
  "status": "OK",
  "timestamp": "2025-09-25T12:16:07.667164512Z",
  "system": {
    "version": "go1.24.7",
    "goroutines_count": 23,
    "total_alloc_bytes": 74547568,
    "heap_objects_count": 99256,
    "alloc_bytes": 37762696
  },
  "component": {
    "name": "eventstream-listener",
    "version": "1.0.0"
  }
}`