### PR TITLE
Add Kafka consumer access check, using QueryWatermarkOffsets

### DIFF
--- a/health/kafka_test.go
+++ b/health/kafka_test.go
@@ -320,7 +320,7 @@ func (s *AccessCheckTestSuite) TestKafkaConsumerAccessCheck() {
 	if s.expectedErr == nil {
 		s.NoError(err)
 	} else {
-		s.Error(err, s.expectedErr)
+		s.EqualError(err, s.expectedErr.Error())
 	}
 }
 

--- a/health/schema_registry.go
+++ b/health/schema_registry.go
@@ -32,7 +32,7 @@ func (c *SchemaRegistryChecker) Check(ctx context.Context) error {
 		return fmt.Errorf("error /subjects not reachable: %w", err)
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("error unable to query /subjects: status %d", resp.StatusCode)


### PR DESCRIPTION
This was tested locally with realtime API. It fails when the topic doesn't exist and passes otherwise.